### PR TITLE
Fixed URL handling, '0 frames' stall, and error handling - Knew

### DIFF
--- a/plugins/GifCaptioner/src/index.ts
+++ b/plugins/GifCaptioner/src/index.ts
@@ -14,86 +14,131 @@ import { Api } from "$shared/bd";
 addFont(futura, "futuraBoldCondensed");
 
 after(gifDisplay.prototype, "render", ({ thisVal, returnVal }) => {
-    const button = BdApi.React.createElement("button", {
-        className: "gc-trigger",
-        onClick: (e) => {
-            e.stopPropagation();
-            const isGif = thisVal.props.format === 1;
-            const rawUrl = thisVal.props.src;
-            const url = formatUrl(rawUrl);
-            Api.Logger.info("URL formatted to", url);
+	const button = BdApi.React.createElement("button", {
+		className: "gc-trigger",
+		onClick: (e) => {
+			e.stopPropagation();
 
-            if(isGif) {
-                let image = document.createElement("img");
-                image.src = url;
-                
-                image.addEventListener("load", () => {
-                    // For some reason the height and width change once added to the dom
-                    let { width, height } = image;
-                    showCaptioner(width, height, image, (transform) => {
-                        captionGif(url, width, height, transform);
-                    });
-                });
-                image.addEventListener("error", () => error("Failed to load gif"));
-            } else {
-                let video = document.createElement("video");
-                video.src = url;
-                video.autoplay = true;
-                video.loop = true;
-                video.muted = true;
-                video.load();
+			const rawUrl = thisVal.props.src;
+			const url = formatUrl(rawUrl);
+			Api.Logger.info("URL formatted to", url);
 
-                video.addEventListener("canplaythrough", () => {
-                    let { videoWidth, videoHeight } = video;
-                    showCaptioner(videoWidth, videoHeight, video, (transform) => {
-                        captionMp4(url, videoWidth, videoHeight, transform);
-                    });
-                }, { once: true });
-                video.addEventListener("error", () => error("Failed to load gif"));
-            }
-        }
-    }, BdApi.React.createElement(CCIcon));
+			const lowerUrl = url.toLowerCase();
+			const looksGif = lowerUrl.includes(".gif");
+			const looksVideo = lowerUrl.includes(".mp4") || lowerUrl.includes(".webm");
 
-    returnVal.props.children.unshift(button);
+			// Tenor embeds often render as GIFs in the client UI, but the underlying media is usually MP4/WebM. - Knew
+			const isGif = looksVideo ? false : (looksGif ? true : thisVal.props.format === 1);
+
+			if (isGif) {
+				const image = document.createElement("img");
+				image.src = url;
+
+				image.addEventListener("load", () => {
+					// For some reason the height and width change once added to the DOM.
+					const { width, height } = image;
+					showCaptioner(width, height, image, (transform) => {
+						captionGif(url, width, height, transform).catch((err) => {
+							Api.Logger.error("captionGif failed", err);
+							error(`Encode failed: ${String(err?.message || err)}`);
+						});
+					});
+				});
+
+				image.addEventListener("error", () => error("Failed to load gif"));
+			} else {
+				const video = document.createElement("video");
+				video.src = url;
+				video.autoplay = true;
+				video.loop = true;
+				video.muted = true;
+				video.load();
+
+				video.addEventListener("canplaythrough", () => {
+					const { videoWidth, videoHeight } = video;
+					showCaptioner(videoWidth, videoHeight, video, (transform) => {
+						captionMp4(url, videoWidth, videoHeight, transform).catch((err) => {
+							Api.Logger.error("captionMp4 failed", err);
+							error(`Encode failed: ${String(err?.message || err)}`);
+						});
+					});
+				}, { once: true });
+
+				video.addEventListener("error", () => error("Failed to load gif"));
+			}
+		}
+	}, BdApi.React.createElement(CCIcon));
+
+	returnVal.props.children.unshift(button);
 });
 
 function showCaptioner(width: number, height: number, element: HTMLElement, onConfirm: (transform: GifTransform) => void) {
-    let submitCallback: () => GifTransform;
+	let submitCallback: () => GifTransform;
 
-    const modal = BdApi.React.createElement(Modal, {
-        width,
-        height,
-        element,
-        onSubmit: (cb) => submitCallback = cb
-    });
+	const modal = BdApi.React.createElement(Modal, {
+		width,
+		height,
+		element,
+		onSubmit: (cb) => submitCallback = cb
+	});
 
-    BdApi.UI.showConfirmationModal("Edit GIF", modal, {
-        onConfirm: () => {
-            expressionPicker.close();
-            let res = submitCallback?.();
-            if(res) onConfirm(res);
-        }
-    });
+	BdApi.UI.showConfirmationModal("Edit GIF", modal, {
+		onConfirm: () => {
+			expressionPicker.close();
+			const res = submitCallback?.();
+			if (res) onConfirm(res);
+		}
+	});
+}
+
+function unwrapDiscordExternalUrl(inputUrl: string): string {
+	try {
+		let fixed = inputUrl;
+		if (fixed.startsWith("//")) fixed = "https:" + fixed;
+
+		const u = new URL(fixed, location.href);
+		const host = u.hostname.toLowerCase();
+
+		// Favourited Tenor links (sometimes) end up as external.discordapp.net URLs, and it is more simple to unwrap this for 'gif.ts' and 'video.ts'. - Knew
+		// More clean to just not have this, but it makes things more complex ouside this code. - Knew
+		if (!host.startsWith("external.") || (!host.endsWith("discordapp.net") && !host.endsWith("discordapp.com"))) return fixed;
+
+		const httpsMarker = "/https/";
+		const httpsIdx = u.pathname.indexOf(httpsMarker);
+		if (httpsIdx !== -1) return "https://" + u.pathname.slice(httpsIdx + httpsMarker.length) + u.search;
+
+		const httpMarker = "/http/";
+		const httpIdx = u.pathname.indexOf(httpMarker);
+		if (httpIdx !== -1) return "http://" + u.pathname.slice(httpIdx + httpMarker.length) + u.search;
+
+		return fixed;
+	} catch {
+		return inputUrl;
+	}
 }
 
 function formatUrl(rawUrl: string) {
-    const url = new URL(rawUrl, location.href);
+	const unwrapped = unwrapDiscordExternalUrl(rawUrl);
+	const url = new URL(unwrapped, location.href);
 
-    // Prefer using discord CDN (thanks Knew)
-    if (url.hostname === "media.discordapp.net") url.hostname = "cdn.discordapp.com";
-    url.searchParams.delete("format");
-    url.searchParams.delete("animated");
-    url.searchParams.delete("width");
-    url.searchParams.delete("height");
-    url.searchParams.delete("quality");
+	// Prefer using Discord CDN/COM over the MEDIA/NET URL (thanks Knew)
+	if (url.hostname === "media.discordapp.net") url.hostname = "cdn.discordapp.com";
 
-    // Prefer using mp4 from tenor for higher quality
-    // For some reason tenor denotes this by ending the id with an o
-    if(url.hostname.endsWith("tenor.com")) {
-        const path = url.pathname;
-        const typeIndex = path.lastIndexOf("/") - 1;
-        url.pathname = path.slice(0, typeIndex) + "o" + path.slice(typeIndex + 1);
-    }
+	url.searchParams.delete("format");
+	url.searchParams.delete("animated");
+	url.searchParams.delete("width");
+	url.searchParams.delete("height");
+	url.searchParams.delete("quality");
 
-    return url.toString();
+	// Prefer using MP4 from Tenor for higher quality.
+	// Tenor denotes this by ending the ID segment with an "o".
+	if (url.hostname.endsWith("tenor.com")) {
+		const path = url.pathname;
+		const typeIndex = path.lastIndexOf("/") - 1;
+		if (typeIndex >= 0 && typeIndex < path.length) {
+			url.pathname = path.slice(0, typeIndex) + "o" + path.slice(typeIndex + 1);
+		}
+	}
+
+	return url.toString();
 }

--- a/plugins/GifCaptioner/src/index.ts
+++ b/plugins/GifCaptioner/src/index.ts
@@ -14,180 +14,180 @@ import { Api } from "$shared/bd";
 addFont(futura, "futuraBoldCondensed");
 
 after(gifDisplay.prototype, "render", ({ thisVal, returnVal }) => {
-	const button = BdApi.React.createElement("button", {
-		className: "gc-trigger",
-		onClick: (e) => {
-			e.stopPropagation();
+    const button = BdApi.React.createElement("button", {
+        className: "gc-trigger",
+        onClick: (e) => {
+            e.stopPropagation();
 
-			try {
-				const rawUrl = thisVal?.props?.src;
-				if (!rawUrl || typeof rawUrl !== "string") {
-					Api.Logger.error("[GifCaptioner] Missing media URL", { rawUrl });
-					error("Failed to read media URL.");
-					return;
-				}
+            try {
+                const rawUrl = thisVal?.props?.src;
+                if (!rawUrl || typeof rawUrl !== "string") {
+                    Api.Logger.error("[GifCaptioner] Missing media URL", { rawUrl });
+                    error("Failed to read media URL.");
+                    return;
+                }
 
-				const url = formatUrl(rawUrl);
-				Api.Logger.info("URL formatted to", url);
+                const url = formatUrl(rawUrl);
+                Api.Logger.info("URL formatted to", url);
 
-				const lowerUrl = url.toLowerCase();
-				const looksGif = lowerUrl.includes(".gif");
-				const looksVideo = lowerUrl.includes(".mp4") || lowerUrl.includes(".webm");
+                const lowerUrl = url.toLowerCase();
+                const looksGif = lowerUrl.includes(".gif");
+                const looksVideo = lowerUrl.includes(".mp4") || lowerUrl.includes(".webm");
 
-				// Tenor embeds often render as GIFs in the client UI, but the underlying media is usually MP4/WebM. - Knew
-				const isGif = looksVideo ? false : (looksGif ? true : thisVal.props.format === 1);
+                // Tenor embeds often render as GIFs in the client UI, but the underlying media is usually MP4/WebM. - Knew
+                const isGif = looksVideo ? false : (looksGif ? true : thisVal.props.format === 1);
 
-				if (!looksGif && !looksVideo && typeof thisVal?.props?.format !== "number") {
-					Api.Logger.error("[GifCaptioner] Unsupported media type", { url });
-					error("Unsupported media type for captioning.");
-					return;
-				}
+                if (!looksGif && !looksVideo && typeof thisVal?.props?.format !== "number") {
+                    Api.Logger.error("[GifCaptioner] Unsupported media type", { url });
+                    error("Unsupported media type for captioning.");
+                    return;
+                }
 
-				if (isGif) {
-					const image = document.createElement("img");
-					image.src = url;
+                if (isGif) {
+                    const image = document.createElement("img");
+                    image.src = url;
 
-					image.addEventListener("load", () => {
-						try {
-							// For some reason the height and width change once added to the DOM.
-							const { width, height } = image;
-							if (!width || !height) {
-								Api.Logger.error("[GifCaptioner] Invalid image dimensions", { url, width, height });
-								error("Failed to read GIF dimensions.");
-								return;
-							}
+                    image.addEventListener("load", () => {
+                        try {
+                            // For some reason the height and width change once added to the DOM.
+                            const { width, height } = image;
+                            if (!width || !height) {
+                                Api.Logger.error("[GifCaptioner] Invalid image dimensions", { url, width, height });
+                                error("Failed to read GIF dimensions.");
+                                return;
+                            }
 
-							showCaptioner(width, height, image, (transform) => {
-								captionGif(url, width, height, transform).catch((err) => {
-									console.error("[GifCaptioner] captionGif (encode) failed:", { url, err });
-									error(`Encode failed: ${String(err?.message || err)}`);
-								});
-							});
-						} catch (err) {
-							console.error("[GifCaptioner] GIF preview load handler failed:", { url, err });
-							error(`Failed to open editor: ${String(err?.message || err)}`);
-						}
-					});
+                            showCaptioner(width, height, image, (transform) => {
+                                captionGif(url, width, height, transform).catch((err) => {
+                                    console.error("[GifCaptioner] captionGif (encode) failed:", { url, err });
+                                    error(`Encode failed: ${String(err?.message || err)}`);
+                                });
+                            });
+                        } catch (err) {
+                            console.error("[GifCaptioner] GIF preview load handler failed:", { url, err });
+                            error(`Failed to open editor: ${String(err?.message || err)}`);
+                        }
+                    });
 
-					image.addEventListener("error", (ev) => {
-						console.error("[GifCaptioner] Preview image failed to load:", url, ev);
-						error("Failed to load gif");
-					});
-				} else { //isVideo
-					const video = document.createElement("video");
-					video.src = url;
-					video.autoplay = true;
-					video.loop = true;
-					video.muted = true;
-					video.load();
+                    image.addEventListener("error", (ev) => {
+                        console.error("[GifCaptioner] Preview image failed to load:", url, ev);
+                        error("Failed to load gif");
+                    });
+                } else { //isVideo
+                    const video = document.createElement("video");
+                    video.src = url;
+                    video.autoplay = true;
+                    video.loop = true;
+                    video.muted = true;
+                    video.load();
 
-					video.addEventListener("canplaythrough", () => {
-						try {
-							const { videoWidth, videoHeight } = video;
-							if (!videoWidth || !videoHeight) {
-								Api.Logger.error("[GifCaptioner] Invalid video dimensions", { url, videoWidth, videoHeight });
-								error("Failed to read video dimensions.");
-								return;
-							}
+                    video.addEventListener("canplaythrough", () => {
+                        try {
+                            const { videoWidth, videoHeight } = video;
+                            if (!videoWidth || !videoHeight) {
+                                Api.Logger.error("[GifCaptioner] Invalid video dimensions", { url, videoWidth, videoHeight });
+                                error("Failed to read video dimensions.");
+                                return;
+                            }
 
-							showCaptioner(videoWidth, videoHeight, video, (transform) => {
-								captionMp4(url, videoWidth, videoHeight, transform).catch((err) => {
-									console.error("[GifCaptioner] captionMp4 (encode) failed:", { url, err });
-									error(`Encode failed: ${String(err?.message || err)}`);
-								});
-							});
-						} catch (err) {
-							console.error("[GifCaptioner] Video preview load handler failed:", { url, err });
-							error(`Failed to open editor: ${String(err?.message || err)}`);
-						}
-					}, { once: true });
+                            showCaptioner(videoWidth, videoHeight, video, (transform) => {
+                                captionMp4(url, videoWidth, videoHeight, transform).catch((err) => {
+                                    console.error("[GifCaptioner] captionMp4 (encode) failed:", { url, err });
+                                    error(`Encode failed: ${String(err?.message || err)}`);
+                                });
+                            });
+                        } catch (err) {
+                            console.error("[GifCaptioner] Video preview load handler failed:", { url, err });
+                            error(`Failed to open editor: ${String(err?.message || err)}`);
+                        }
+                    }, { once: true });
 
-					video.addEventListener("error", (ev) => {
-						console.error("[GifCaptioner] Preview video failed to load:", url, ev);
-						error("Failed to load gif");
-					});
-				}
-			} catch (err) {
-				console.error("[GifCaptioner] Click handler failed:", err);
-				error(`Failed to prepare media: ${String(err?.message || err)}`);
-			}
-		}
-	}, BdApi.React.createElement(CCIcon));
+                    video.addEventListener("error", (ev) => {
+                        console.error("[GifCaptioner] Preview video failed to load:", url, ev);
+                        error("Failed to load gif");
+                    });
+                }
+            } catch (err) {
+                console.error("[GifCaptioner] Click handler failed:", err);
+                error(`Failed to prepare media: ${String(err?.message || err)}`);
+            }
+        }
+    }, BdApi.React.createElement(CCIcon));
 
-	returnVal.props.children.unshift(button);
+    returnVal.props.children.unshift(button);
 });
 
 function showCaptioner(width: number, height: number, element: HTMLElement, onConfirm: (transform: GifTransform) => void) {
-	let submitCallback: () => GifTransform;
+    let submitCallback: () => GifTransform;
 
-	const modal = BdApi.React.createElement(Modal, {
-		width,
-		height,
-		element,
-		onSubmit: (cb) => submitCallback = cb
-	});
+    const modal = BdApi.React.createElement(Modal, {
+        width,
+        height,
+        element,
+        onSubmit: (cb) => submitCallback = cb
+    });
 
-	BdApi.UI.showConfirmationModal("Edit GIF", modal, {
-		onConfirm: () => {
-			try {
-				expressionPicker.close();
-				const res = submitCallback?.();
-				if (res) onConfirm(res);
-			} catch (err) {
-				console.error("[GifCaptioner] Submit failed:", err);
-				error(`Failed to submit: ${String(err?.message || err)}`);
-			}
-		}
-	});
+    BdApi.UI.showConfirmationModal("Edit GIF", modal, {
+        onConfirm: () => {
+            try {
+                expressionPicker.close();
+                const res = submitCallback?.();
+                if (res) onConfirm(res);
+            } catch (err) {
+                console.error("[GifCaptioner] Submit failed:", err);
+                error(`Failed to submit: ${String(err?.message || err)}`);
+            }
+        }
+    });
 }
 
 function unwrapDiscordExternalUrl(inputUrl: string): string {
-	try {
-		let fixed = inputUrl;
-		if (fixed.startsWith("//")) fixed = "https:" + fixed;
+    try {
+        let fixed = inputUrl;
+        if (fixed.startsWith("//")) fixed = "https:" + fixed;
 
-		const u = new URL(fixed, location.href);
-		const host = u.hostname.toLowerCase();
+        const u = new URL(fixed, location.href);
+        const host = u.hostname.toLowerCase();
 
-		// Favourited Tenor links (sometimes) end up as 'external.discordapp.net' URLs, and it is more simple to unwrap this for 'gif.ts' and 'video.ts'. - Knew
-		if (!host.startsWith("external.") || (!host.endsWith("discordapp.net") && !host.endsWith("discordapp.com"))) return fixed;
+        // Favourited Tenor links (sometimes) end up as 'external.discordapp.net' URLs, and it is more simple to unwrap this for 'gif.ts' and 'video.ts'. - Knew
+        if (!host.startsWith("external.") || (!host.endsWith("discordapp.net") && !host.endsWith("discordapp.com"))) return fixed;
 
-		const httpsMarker = "/https/";
-		const httpsIdx = u.pathname.indexOf(httpsMarker);
-		if (httpsIdx !== -1) return "https://" + u.pathname.slice(httpsIdx + httpsMarker.length) + u.search;
+        const httpsMarker = "/https/";
+        const httpsIdx = u.pathname.indexOf(httpsMarker);
+        if (httpsIdx !== -1) return "https://" + u.pathname.slice(httpsIdx + httpsMarker.length) + u.search;
 
-		const httpMarker = "/http/";
-		const httpIdx = u.pathname.indexOf(httpMarker);
-		if (httpIdx !== -1) return "http://" + u.pathname.slice(httpIdx + httpMarker.length) + u.search;
+        const httpMarker = "/http/";
+        const httpIdx = u.pathname.indexOf(httpMarker);
+        if (httpIdx !== -1) return "http://" + u.pathname.slice(httpIdx + httpMarker.length) + u.search;
 
-		return fixed;
-	} catch {
-		return inputUrl;
-	}
+        return fixed;
+    } catch {
+        return inputUrl;
+    }
 }
 
 function formatUrl(rawUrl: string) {
-	const unwrapped = unwrapDiscordExternalUrl(rawUrl);
-	const url = new URL(unwrapped, location.href);
+    const unwrapped = unwrapDiscordExternalUrl(rawUrl);
+    const url = new URL(unwrapped, location.href);
 
-	// Prefer using Discord CDN/COM over the MEDIA/NET URL (thanks Knew)
-	if (url.hostname === "media.discordapp.net") url.hostname = "cdn.discordapp.com";
+    // Prefer using Discord CDN/COM over the MEDIA/NET URL (thanks Knew)
+    if (url.hostname === "media.discordapp.net") url.hostname = "cdn.discordapp.com";
 
-	url.searchParams.delete("format");
-	url.searchParams.delete("animated");
-	url.searchParams.delete("width");
-	url.searchParams.delete("height");
-	url.searchParams.delete("quality");
+    url.searchParams.delete("format");
+    url.searchParams.delete("animated");
+    url.searchParams.delete("width");
+    url.searchParams.delete("height");
+    url.searchParams.delete("quality");
 
-	// Prefer using MP4 from Tenor for higher quality.
-	// Tenor denotes this by ending the ID segment with an "o".
-	if (url.hostname.endsWith("tenor.com")) {
-		const path = url.pathname;
-		const typeIndex = path.lastIndexOf("/") - 1;
-		if (typeIndex >= 0 && typeIndex < path.length) {
-			url.pathname = path.slice(0, typeIndex) + "o" + path.slice(typeIndex + 1);
-		}
-	}
+    // Prefer using MP4 from Tenor for higher quality.
+    // Tenor denotes this by ending the ID segment with an "o".
+    if (url.hostname.endsWith("tenor.com")) {
+        const path = url.pathname;
+        const typeIndex = path.lastIndexOf("/") - 1;
+        if (typeIndex >= 0 && typeIndex < path.length) {
+            url.pathname = path.slice(0, typeIndex) + "o" + path.slice(typeIndex + 1);
+        }
+    }
 
-	return url.toString();
+    return url.toString();
 }


### PR DESCRIPTION
### Summary:
Refactor GIF/video handling in the `render` hook to improve URL normalization and error handling, preventing Discord media-proxy links from breaking animated GIF decoding.

### The issue:
When selecting a GIF (especially from favorites), Discord can hand the plugin a media-proxy URL like:
- `https://media.discordapp.net/attachments/.../rendered.gif?...&format=webp&width=471&height=350`

The important part is `format=webp` (plus `width/height/quality/animated`), which can force the asset into a still thumbnail/transcoded representation rather than the original animated GIF. That mismatch is what leads to the "0 frame stall" / decode failures.

This is the same class of problem that showed up in my 'Uncompressed Images' plugins; the URL looks like a GIF, but the proxy parameters change what you actually receive.

### What this PR changes:
- Normalizes Discord media URLs before preview/encode by:
  - Converting `media.discordapp.net` to `cdn.discordapp.com`
  - Removing proxy/transcode query params (`format`, `width`, `height`, `quality`, `animated`)
- Adds fetch/resolve error handling so failures surface earlier with clearer messages (instead of failing deep in the encoder without ever telling you, or the user anything).